### PR TITLE
Search Local Documentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
     },
     "cSpell.words": [
         "ilgarmehmetali",
+        "msft",
         "ycleptic"
     ],
     "markdownlint.config": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,13 +5,12 @@
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results
     },
-    "cSpell.words": [
-        "ilgarmehmetali",
-        "msft",
-        "ycleptic"
-    ],
     "markdownlint.config": {
         "MD026": { "punctuation": ".,;:!" },
         "MD024": false
-    }
+    },
+    "cSpell.ignoreWords": [
+        "iexplore",
+        "msft"
+    ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.2] - 2020-01-02
+
+### Added
+
+- Search local documentation. NOTE: THIS IS UNTESTED ON MAC AND LINUX! Thanks [@rostok](https://github.com/rostok) for the help.
+- Set documentation version for online documentation. Thanks [@mccorkle](https://github.com/mccorkle)
+
 ## [1.1.1] - 2019-06-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -83,12 +83,9 @@ If you rather search local documentation rather than online, set a value to unit
 
 **NOTE:** unity-tools.localDocumentationPath should end with a trailing slash `/`, but should not include `file:///` nor any filename like `index.html` or `30_search.html`
 
-Due to the nature of queries in local file paths (at least on Windows, I have not tested on Mac/Linux), you are also required to set a default browser with unity-tools.localDocumentationViewer. For example, "firefox", "iexplore", or "chrome". If you do not set this, or set it as blank, the documentation will open but your query/selection will be lost.
-
 ```json
 {
-    "unity-tools.localDocumentationPath" : "Applications/Unity/Documentation/en/ScriptReference/",
-    "unity-tools.localDocumentationViewer" : "firefox"
+    "unity-tools.localDocumentationPath" : "Applications/Unity/Documentation/en/ScriptReference/"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ If you rather search local documentation rather than online, set a value to unit
 
 **NOTE:** unity-tools.localDocumentationPath should end with a trailing slash `/`, but should not include `file:///` nor any filename like `index.html` or `30_search.html`
 
-Due to the nature of queries in local file paths (at least on Windows, I have not tested on Mac/Linux), you are also required to set a default browser with unity-tools.localDocumentationViewer. For example, "firefox", "iexplore", or "chrome". If you do not set this, or set it as blank, the documentation will open but your query/selection will be lost.
+Due to the nature of queries in local file paths (at least on Windows, I have not tested on Mac/Linux), you are also required to set a default browser with unity-tools.localDocumentationViewer. For example, `firefox`, `iexplore`, or `chrome`. You can also set the exact path, if your browser doesn't have a command. Example: `C:/Program Files/Mozilla Firefox/firefox.exe`
+
+If you do not set localDocumentationViewer, localDocumentationPath will not work.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ To do this simply open or create `./.vscode/settings.json` and fill in the below
 }
 ```
 
+You can also set which Unity version should be used when accessing online documentation. Make sure the version number you enter is valid for Unity's documentation.
+
+```json
+{
+    "unity-tools.documentationVersion" : "2018.4"
+}
+```
+
 You can also enable/disable the "Open Documentation" option in right-click menu by the below setting. Default value is true.
 
 ```json
@@ -81,11 +89,11 @@ You can also enable/disable the "Open Documentation" option in right-click menu 
 
 If you rather search local documentation rather than online, set a value to unity-tools.localDocumentationPath.
 
-**NOTE:** unity-tools.localDocumentationPath should end with a trailing slash `/`, but should not include `file:///` nor any filename like `index.html` or `30_search.html`
+**NOTE:** unity-tools.localDocumentationPath should NOT include a trailing slash `/`, `file:///` nor any filename like `index.html` or `30_search.html`
 
 Due to the nature of queries in local file paths (at least on Windows, I have not tested on Mac/Linux), you are also required to set a default browser with unity-tools.localDocumentationViewer. For example, `firefox`, `iexplore`, or `chrome`. You can also set the exact path, if your browser doesn't have a command. Example: `C:/Program Files/Mozilla Firefox/firefox.exe`
 
-If you do not set localDocumentationViewer, localDocumentationPath will not work.
+If you do not set localDocumentationViewer, localDocumentationPath will not work. This may or may not be true on Mac or Linux, I have not had the opportunity to test it! If you have, please let me know.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Added the pallet command "Unity Tools: Generate Organizational Folders" to creat
 ### Configuration
 
 The Unity-Tools command Generate Organizational Folders can be configured to create a set of folders of your choosing, instead of the 5 default ones: Scenes, Scripts, Prefabs, Materials, and Audio.
-To do this simply open or create `./.vscode/settings.json` and fill in the following fields:
+To do this simply open or create `./.vscode/settings.json` and fill in the below fields.
 
 ```json
 {
@@ -71,7 +71,7 @@ To do this simply open or create `./.vscode/settings.json` and fill in the follo
 }
 ```
 
-You can also enable/disable the "Open Documentation" option in right-click menu by the following setting (default true):
+You can also enable/disable the "Open Documentation" option in right-click menu by the below setting. Default value is true.
 
 ```json
 {
@@ -79,13 +79,16 @@ You can also enable/disable the "Open Documentation" option in right-click menu 
 }
 ```
 
-If you rather search local documentation rather than online, set a value to unity-tools.localDocumentationPath:
+If you rather search local documentation rather than online, set a value to unity-tools.localDocumentationPath.
 
-**NOTE:** This should end with a trailing slash `/`, but should not include `file:///` nor any filename like `index.html` or `30_search.html`
+**NOTE:** unity-tools.localDocumentationPath should end with a trailing slash `/`, but should not include `file:///` nor any filename like `index.html` or `30_search.html`
+
+Due to the nature of queries in local file paths (at least on Windows, I have not tested on Mac/Linux), you are also required to set a default browser with unity-tools.localDocumentationViewer. For example, "firefox", "iexplore", or "chrome". If you do not set this, or set it as blank, the documentation will open but your query/selection will be lost.
 
 ```json
 {
-    "unity-tools.localDocumentationPath" : "Applications/Unity/Documentation/en/ScriptReference/"
+    "unity-tools.localDocumentationPath" : "Applications/Unity/Documentation/en/ScriptReference/",
+    "unity-tools.localDocumentationViewer" : "firefox"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,12 @@ If you rather search local documentation rather than online, set a value to unit
 
 **NOTE:** unity-tools.localDocumentationPath should end with a trailing slash `/`, but should not include `file:///` nor any filename like `index.html` or `30_search.html`
 
+Due to the nature of queries in local file paths (at least on Windows, I have not tested on Mac/Linux), you are also required to set a default browser with unity-tools.localDocumentationViewer. For example, "firefox", "iexplore", or "chrome". If you do not set this, or set it as blank, the documentation will open but your query/selection will be lost.
+
 ```json
 {
-    "unity-tools.localDocumentationPath" : "Applications/Unity/Documentation/en/ScriptReference/"
+    "unity-tools.localDocumentationPath" : "Applications/Unity/Documentation/en/ScriptReference/",
+    "unity-tools.localDocumentationViewer" : "firefox"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ You can also enable/disable the "Open Documentation" option in right-click menu 
 }
 ```
 
+If you rather search local documentation rather than online, set a value to unity-tools.localDocumentationPath:
+
+**NOTE:** This should end with a trailing slash `/`, but should not include `file:///` nor any filename like `index.html` or `30_search.html`
+
+```json
+{
+    "unity-tools.localDocumentationPath" : "Applications/Unity/Documentation/en/ScriptReference/"
+}
+```
+
 ## Other resources
 
 Here are some other resources I recommend:

--- a/package-lock.json
+++ b/package-lock.json
@@ -440,6 +440,11 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -617,6 +622,14 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "open": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.3.0.tgz",
+      "integrity": "sha512-6AHdrJxPvAXIowO/aIaeHZ8CeMdDf7qCyRNq8NwJpinmCdXhz+NZR7ie1Too94lpciCDsG+qHGO9Mt0svA4OqA==",
+      "requires": {
+        "is-wsl": "^1.1.0"
       }
     },
     "path-is-absolute": {

--- a/package.json
+++ b/package.json
@@ -110,11 +110,6 @@
           "type": "string",
           "default": "",
           "description": "The path to local documentation, as opposed to going online. For example: \"Applications/Unity/Documentation/en/ScriptReference/\" - NOTE: Leave a trailing slash, but do not include any file target nor file:///"
-        },
-        "unity-tools.localDocumentationViewer": {
-          "type": "string",
-          "default": "firefox",
-          "description": "The path command for the browser you'd like to use to open local file documentation. Example: firefox, iexplore, chrome. Must be defined if using unity-tools.localDocumentationPath"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,11 @@
           "type": "boolean",
           "default": true,
           "description": "Enables the \"Open Documentation\" option on right-click menu."
+        },
+        "unity-tools.localDocumentationPath": {
+          "type": "string",
+          "default": "",
+          "description": "The path to local documentation, as opposed to going online. For example: \"Applications/Unity/Documentation/en/ScriptReference/\" - NOTE: Leave a trailing slash, but do not include any file target nor file:///"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -101,6 +101,11 @@
           ],
           "description": "Sets which folders will be generated from the unity-tools.GenerateOrganizationFolders command"
         },
+        "unity-tools.documentationVersion": {
+          "type": "string",
+          "default": "",
+          "description": "Which Unity version should be used for online documentation? Example: \"2020.1\" or \"2018.4\""
+        },
         "unity-tools.enableRightClickSearch": {
           "type": "boolean",
           "default": true,
@@ -109,7 +114,7 @@
         "unity-tools.localDocumentationPath": {
           "type": "string",
           "default": "",
-          "description": "The path to local documentation, as opposed to going online. For example: \"Applications/Unity/Documentation/en/ScriptReference/\" - NOTE: Leave a trailing slash, but do not include any file target nor file:///"
+          "description": "The path to local documentation, as opposed to going online. Example: \"Applications/Unity/Documentation/en/ScriptReference\" - NOTE: Do NOT include a trailing slash, file target or file:///"
         },
         "unity-tools.localDocumentationViewer": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -114,8 +114,9 @@
         "unity-tools.localDocumentationViewer": {
           "type": "string",
           "default": "firefox",
-          "description": "The path command for the browser you'd like to use to open local file documentation. Example: 'firefox', 'iexplore', 'chrome'. Must be defined if using unity-tools.localDocumentationPath"
+          "description": "The path command for the browser you'd like to use to open local file documentation. Example: \"firefox\", \"iexplore\", \"chrome\". Must be defined if using unity-tools.localDocumentationPath"
         }
+      }
     }
   },
   "scripts": {
@@ -132,5 +133,8 @@
     "typescript": "^3.5.1",
     "vscode": "^1.1.34"
   },
-  "icon": "unity-logo.png"
+  "icon": "unity-logo.png",
+  "dependencies": {
+    "open": "^6.3.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -110,6 +110,11 @@
           "type": "string",
           "default": "",
           "description": "The path to local documentation, as opposed to going online. For example: \"Applications/Unity/Documentation/en/ScriptReference/\" - NOTE: Leave a trailing slash, but do not include any file target nor file:///"
+        },
+        "unity-tools.localDocumentationViewer": {
+          "type": "string",
+          "default": "firefox",
+          "description": "The path command for the browser you'd like to use to open local file documentation. Example: firefox, iexplore, chrome. Must be defined if using unity-tools.localDocumentationPath"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -110,8 +110,12 @@
           "type": "string",
           "default": "",
           "description": "The path to local documentation, as opposed to going online. For example: \"Applications/Unity/Documentation/en/ScriptReference/\" - NOTE: Leave a trailing slash, but do not include any file target nor file:///"
+        },
+        "unity-tools.localDocumentationViewer": {
+          "type": "string",
+          "default": "firefox",
+          "description": "The path command for the browser you'd like to use to open local file documentation. Example: 'firefox', 'iexplore', 'chrome'. Must be defined if using unity-tools.localDocumentationPath"
         }
-      }
     }
   },
   "scripts": {

--- a/src/search.ts
+++ b/src/search.ts
@@ -4,6 +4,7 @@ let msft_search = "https://docs.microsoft.com/";
 let msft_search_url = "en-us/search/index?search=";
 
 import * as vscode from 'vscode';
+const open = require('open');
 
 export async function openURL(search_base?: string, s?: string) {
 	if (search_base === "open") { await vscode.env.openExternal(vscode.Uri.parse(s as string)); } else {
@@ -20,9 +21,9 @@ export async function openURL(search_base?: string, s?: string) {
 			}
 			else
 			{
-				appPath = settings.get('localDocumentationViewer',"firefox");
+				appPath = settings.get('localDocumentationViewer',"");
 
-				search_blank_url = localPath+"30_search.html";
+				search_blank_url = "file:///"+localPath+"30_search.html";
 				local = true;
 			}
 			search_url = search_blank_url+unity_search_url;
@@ -36,7 +37,7 @@ export async function openURL(search_base?: string, s?: string) {
 		else { s = search_url + s; }
 
 		if (local) {
-			// TODO: Add Opn here
+			await open(s as string, { app: appPath });
 		}
 		else
 		{

--- a/src/search.ts
+++ b/src/search.ts
@@ -10,8 +10,18 @@ export async function openURL(search_base?: string, s?: string) {
 		var search_blank_url, search_url;
 
 		if (search_base === "unity") {
-			search_blank_url = unity_search;
-			search_url = unity_search_url;
+			var settings: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('unity-tools');
+			var localPath = settings.get('localDocumentationPath',"");
+			
+			if (localPath === "") {
+				search_blank_url = unity_search;
+			}
+			else
+			{
+				search_blank_url = "file:///"+localPath+"30_search.html";
+			}
+
+			search_url = search_blank_url+unity_search_url;
 		}
 		else if (search_base === "msft") {
 			search_blank_url = msft_search;

--- a/src/search.ts
+++ b/src/search.ts
@@ -8,6 +8,8 @@ import * as vscode from 'vscode';
 export async function openURL(search_base?: string, s?: string) {
 	if (search_base === "open") { await vscode.env.openExternal(vscode.Uri.parse(s as string)); } else {
 		var search_blank_url, search_url;
+		
+		var appPath = "";
 
 		if (search_base === "unity") {
 			var settings: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('unity-tools');
@@ -19,8 +21,9 @@ export async function openURL(search_base?: string, s?: string) {
 			else
 			{
 				search_blank_url = "file:///"+localPath+"30_search.html";
+				
+				appPath = settings.get('localDocumentationViewer',"firefox");
 			}
-
 			search_url = search_blank_url+unity_search_url;
 		}
 		else if (search_base === "msft") {

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,15 +1,14 @@
 let unity_search = "http://docs.unity3d.com/ScriptReference/30_search.html";
-let unity_search_url = unity_search + "?q=";
+let unity_search_url = "?q=";
 let msft_search = "https://docs.microsoft.com/";
-let msft_search_url = msft_search + "en-us/search/index?search=";
+let msft_search_url = "en-us/search/index?search=";
 
 import * as vscode from 'vscode';
 
 export async function openURL(search_base?: string, s?: string) {
 	if (search_base === "open") { await vscode.env.openExternal(vscode.Uri.parse(s as string)); } else {
 		var search_blank_url, search_url;
-		
-		var appPath = "";
+		var local:boolean = false;
 
 		if (search_base === "unity") {
 			var settings: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('unity-tools');
@@ -20,21 +19,26 @@ export async function openURL(search_base?: string, s?: string) {
 			}
 			else
 			{
-				search_blank_url = "file:///"+localPath+"30_search.html";
-				
-				appPath = settings.get('localDocumentationViewer',"firefox");
+				search_blank_url = localPath+"30_search.html";
+				local = true;
 			}
 			search_url = search_blank_url+unity_search_url;
 		}
 		else if (search_base === "msft") {
 			search_blank_url = msft_search;
-			search_url = msft_search_url;
+			search_url = msft_search + msft_search_url;
 		}
 
 		if (!s) { s = search_blank_url; }
 		else { s = search_url + s; }
 
-		await vscode.env.openExternal(vscode.Uri.parse(s as string));
+		if (local) {
+			await vscode.env.openExternal(vscode.Uri.file(s as string));
+		}
+		else
+		{
+			await vscode.env.openExternal(vscode.Uri.parse(s as string));
+		}
 
 	}
 	return true;

--- a/src/search.ts
+++ b/src/search.ts
@@ -9,6 +9,7 @@ export async function openURL(search_base?: string, s?: string) {
 	if (search_base === "open") { await vscode.env.openExternal(vscode.Uri.parse(s as string)); } else {
 		var search_blank_url, search_url;
 		var local:boolean = false;
+		var appPath = "";
 
 		if (search_base === "unity") {
 			var settings: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('unity-tools');
@@ -19,6 +20,8 @@ export async function openURL(search_base?: string, s?: string) {
 			}
 			else
 			{
+				appPath = settings.get('localDocumentationViewer',"firefox");
+
 				search_blank_url = localPath+"30_search.html";
 				local = true;
 			}
@@ -33,7 +36,7 @@ export async function openURL(search_base?: string, s?: string) {
 		else { s = search_url + s; }
 
 		if (local) {
-			await vscode.env.openExternal(vscode.Uri.file(s as string));
+			// TODO: Add Opn here
 		}
 		else
 		{

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,4 +1,6 @@
-let unity_search = "http://docs.unity3d.com/ScriptReference/30_search.html";
+// Unity search url broken up to allow for documentation version
+let unity_search_root = "http://docs.unity3d.com/";
+let unity_search_path = "ScriptReference/30_search.html";
 let unity_search_url = "?q=";
 let msft_search = "https://docs.microsoft.com/";
 let msft_search_url = "en-us/search/index?search=";
@@ -10,20 +12,30 @@ export async function openURL(search_base?: string, s?: string) {
 	if (search_base === "open") { await vscode.env.openExternal(vscode.Uri.parse(s as string)); } else {
 		var search_blank_url, search_url;
 		var local:boolean = false;
-		var appPath = "";
+		var appPath: string = "";
 
 		if (search_base === "unity") {
 			var settings: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('unity-tools');
-			var localPath = settings.get('localDocumentationPath',"");
+			var localPath: string = settings.get('localDocumentationPath',"");
 			
 			if (localPath === "") {
-				search_blank_url = unity_search;
+				var documentationVersion: string = settings.get('documentationVersion',"");
+				if (documentationVersion === "") {
+					search_blank_url = unity_search_root+unity_search_path;
+				}
+				else
+				{
+					search_blank_url = unity_search_root + documentationVersion + "/Documentation/" + unity_search_path;
+				}
 			}
 			else
 			{
 				appPath = settings.get('localDocumentationViewer',"");
-
-				search_blank_url = "file:///"+localPath+"30_search.html";
+				if (appPath === "") {
+					vscode.window.showErrorMessage("Please set localDocumentationViewer to a valid browser");
+					return false;
+				}
+				search_blank_url = "file:///"+localPath+"/30_search.html";
 				local = true;
 			}
 			search_url = search_blank_url+unity_search_url;


### PR DESCRIPTION
As requested in #7 

I'd like somebody to test this on a Mac and Linux, if possible.

Specifically, can you try setting unity-tools.localDocumentationViewer to "" and see if it works. On windows, it does not, so you have to specifically input your browser.

Normally, opening a url from command line opens the default browser. But if opening a local html file, it will automatically parse the query from the URL (thus opening the search page without the desired search). Opening the specific browser will retain the URL query.

Any thoughts on this as well? Bit of a niche feature and not exactly easy to understand. Don't know if I should add more documentation right up or not worry about it, the few people who care about local docs can figure it out?